### PR TITLE
Fix: nix-shell parameters example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ To regenerate the config (in case of incompatible change in jormungandr after up
 
 You can tweak the blockchain configuration through nix-shell parameters, eg.:
 ```
-nix-shell --arg faucetAmounts "[ 100000 1234444 34556 ]" \
+nix-shell -A shell \
+          --arg faucetAmounts "[ 100000 1234444 34556 ]" \
           --arg numberOfStakePools 2 \
-          --argstr logger_output gelf
+          --argstr logger_output gelf \
           --argstr storage "/tmp/jormungandr-storage" \
           https://github.com/input-output-hk/jormungandr-nix/archive/68168ddb54de32a52b2aeb61f2810cdc84cfc375.tar.gz \
           --run run-jormungandr


### PR DESCRIPTION
Fix #5