### PR TITLE
Fix pool owner address format in `create-stake-pool` script

### DIFF
--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -240,7 +240,7 @@ in let
       cp "$PRIVATE_KEY_PATH" ''${TICKER}_owner_wallet.prv
     fi
     jcli key to-public < ''${TICKER}_owner_wallet.prv > ''${TICKER}_owner_wallet.pub
-    jcli address account "$(cat ''${TICKER}_owner_wallet.pub)" --testing > ''${TICKER}_owner_wallet.address
+    jcli address account "$(cat ''${TICKER}_owner_wallet.pub)" --prefix=addr --testing > ''${TICKER}_owner_wallet.address
 
     jcli key generate --type=SumEd25519_12 > ''${TICKER}_kes.prv
     jcli key to-public < ''${TICKER}_kes.prv > ''${TICKER}_kes.pub


### PR DESCRIPTION
Addresses created without prefix `addr` do not pass PR checks when
registering pool in
https://github.com/cardano-foundation/incentivized-testnet-stakepool-registry.git.
So create pool owner address with the prefix in `create-stake-pool` script.